### PR TITLE
Implement the ability to generate an IE only stylesheet

### DIFF
--- a/stylesheets/_breakpoint.scss
+++ b/stylesheets/_breakpoint.scss
@@ -5,6 +5,7 @@ $breakpoint-default-feature:  'min-width' !default;
 $breakpoint-default-media:    'all'       !default;
 $breakpoint-default-pair:     'width'     !default;
 $breakpoint-to-ems:           false       !default;
+$fix-breakpoint:              false       !default;
 
 //////////////////////////////
 // Breakpoint Mixin
@@ -14,10 +15,10 @@ $breakpoint-to-ems:           false       !default;
   $query:         false !default;
   $query-holder:  false !default;
   $media-string:  false !default;
-  
+
   // Holder for Count;
   $first:         true  !default;
-  
+
   // Initialize Query String
   @if $media != 'all' {
     $media-string: "#{$media} ";
@@ -25,7 +26,7 @@ $breakpoint-to-ems:           false       !default;
   @else {
     $media-string: "";
   }
-  
+
   // If we have a single query, let's just work with that.
   @if type-of(nth($breakpoint, 1)) != 'list' {
     $query: breakpoint-switch($breakpoint, $media-string, true);
@@ -41,9 +42,40 @@ $breakpoint-to-ems:           false       !default;
       }
     }
   }
-  
-  @media #{$query} {
-    @content;
+
+  // If we're outputting for a fixed breakpoint…
+  @if $fix-breakpoint {
+    // … and if we should apply these rules…
+    @if $fix-breakpoint >= nth(breakpoint-values($breakpoint), 1) {
+      // … output the content the user gave us.
+      @content;
+    }
+  } @else {
+    // Otherwise, output it using a regular media query.
+    @media #{$query} {
+      @content;
+    }
+  }
+}
+
+@function breakpoint-values($breakpoint) {
+  // See which is larger.
+  @if length($breakpoint) > 1 {
+    $min-value: 0;
+    $max-value: 0;
+
+    @if nth($breakpoint, 1) > nth($breakpoint, 2) {
+      $min-value: nth($breakpoint, 2);
+      $max-value: nth($breakpoint, 1);
+    }
+    @else {
+      $min-value: nth($breakpoint, 1);
+      $max-value: nth($breakpoint, 2);
+    }
+
+    @return $min-value, $max-value;
+  } @else {
+    @return $breakpoint;
   }
 }
 
@@ -57,7 +89,7 @@ $breakpoint-to-ems:           false       !default;
   $max-value:     false !default;
   $length:        false !default;
   $query:         false !default;
-  
+
   $length: length($breakpoint);
   // Check to see if there is only one item.
   @if $length == 1 {
@@ -65,7 +97,7 @@ $breakpoint-to-ems:           false       !default;
     @if type-of($breakpoint) == 'number' {
       $feature: $breakpoint-default-feature;
     }
-    
+
     // If EM Breakpoints are active, do it!
     @if $breakpoint-to-ems and type-of($value) == 'number' {
       $value: breakpoint-to-base-em($value);
@@ -76,16 +108,9 @@ $breakpoint-to-ems:           false       !default;
   @else if $length == 2 {
     // If both are numbers, we've got a double!
     @if type-of(nth($breakpoint, 1)) == 'number' and type-of(nth($breakpoint, 2)) == 'number' {
-      // See which is larger.
-      @if nth($breakpoint, 1) > nth($breakpoint, 2) {
-        $min-value: nth($breakpoint, 2);
-        $max-value: nth($breakpoint, 1);
-      }
-      @else {
-        $min-value: nth($breakpoint, 1);
-        $max-value: nth($breakpoint, 2);
-      }
-      
+      $min-value: nth(breakpoint-values($breakpoint), 1);
+      $max-value: nth(breakpoint-values($breakpoint), 2);
+
       // If EM Breakpoints are active, do it!
       @if $breakpoint-to-ems and type-of($min-value) == 'number' {
         $min-value: breakpoint-to-base-em($min-value);
@@ -93,7 +118,7 @@ $breakpoint-to-ems:           false       !default;
       @if $breakpoint-to-ems and type-of($max-value) == 'number' {
         $max-value: breakpoint-to-base-em($max-value);
       }
-      
+
       // Min/Max for given
       $query: breakpoint-generate($media-string, $min-feature, $min-value, $first);
       $query: join($query, breakpoint-generate($media-string, $max-feature, $max-value));
@@ -107,12 +132,12 @@ $breakpoint-to-ems:           false       !default;
         $feature: nth($breakpoint, 2);
         $value: nth($breakpoint, 1);
       }
-      
+
       // If EM Breakpoints are active, do it!
       @if $breakpoint-to-ems and type-of($value) == 'number' {
         $value: breakpoint-to-base-em($value);
       }
-      
+
       // Build the Query
       $query: breakpoint-generate($media-string, $feature, $value, $first);
     }
@@ -126,7 +151,7 @@ $breakpoint-to-ems:           false       !default;
         $feature: nth($breakpoint, 2);
         $value: nth($breakpoint, 1);
       }
-      
+
       @if $feature == 'device-pixel-ratio' or $feature == 'min-device-pixel-ratio' or $feature == 'max-device-pixel-ratio' {
         $value: 96 * $value * 1dpi;
         @if $feature == 'device-pixel-ratio' {
@@ -139,12 +164,12 @@ $breakpoint-to-ems:           false       !default;
           $feature: 'max-resolution';
         }
       }
-      
+
       // If EM Breakpoints are active, do it!
       @if $breakpoint-to-ems and type-of($value) == 'number' {
         $value: breakpoint-to-base-em($value);
       }
-      
+
       // Build the Query
       $query: breakpoint-generate($media-string, $feature, $value, $first);
     }
@@ -174,13 +199,13 @@ $breakpoint-to-ems:           false       !default;
         $max-value: nth($breakpoint, 2);
       }
     }
-    
+
     @if $feature == 'device-pixel-ratio' {
       $min-value: 96 * $min-value * 1dpi;
       $max-value: 96 * $max-value * 1dpi;
       $feature: 'resolution';
     }
-    
+
     // If EM Breakpoints are active, do it!
     @if $breakpoint-to-ems and type-of($min-value) == 'number' {
       $min-value: breakpoint-to-base-em($min-value);
@@ -188,7 +213,7 @@ $breakpoint-to-ems:           false       !default;
     @if $breakpoint-to-ems and type-of($max-value) == 'number' {
       $max-value: breakpoint-to-base-em($max-value);
     }
-    
+
     @if breakpoint-min-max($feature) == true {
       $min-feature: 'min-#{$feature}';
       $max-feature: 'max-#{$feature}';
@@ -201,14 +226,14 @@ $breakpoint-to-ems:           false       !default;
       @warn '#{$feature} cannot have a min/max value!';
     }
   }
-  
+
   @return $query;
 }
 
 @function breakpoint-generate($media, $feature, $value, $first: false) {
   // Media Query string to be returned
   $new-string: "";
-  
+
   // If it's the first item, it gets special treatment
   @if $first == true {
     // And Statement
@@ -217,7 +242,7 @@ $breakpoint-to-ems:           false       !default;
     @if $media == '' {
       $and: '';
     }
-    
+
     @if $feature != false {
       $new-string: #{$media}unquote("#{$and}(#{$feature}: #{$value})");
     }
@@ -225,7 +250,7 @@ $breakpoint-to-ems:           false       !default;
       $new-string: #{$media}unquote("#{$and}(#{$value})");
     }
   }
-  
+
   @else {
     @if $feature != false {
       $new-string: unquote("and (#{$feature}: #{$value})");
@@ -234,13 +259,13 @@ $breakpoint-to-ems:           false       !default;
       $new-string: unquote("and (#{$value})");
     }
   }
-  
+
   @return $new-string;
 }
 
 @function breakpoint-to-base-em($value) {
   $unit: unit($value);
-  
+
   @if $unit == 'px' {
     @return $value / 16px * 1em;
   }


### PR DESCRIPTION
When adopting a mobile-first approach, it is important to provide desktop styles to old versions of IE that do not support media queries. This has previously been achieved [without @media bubbling in Sass](http://nicolasgallagher.com/mobile-first-css-sass-and-ie/). Please read [this article by Jake Archibald](http://jakearchibald.github.com/sass-ie/), in which he demonstrates a new method that allows the creation of an IE only stylesheet whilst simultaneously using @media bubbling.

This commit adopts this method, but rather than using the variable name of `$fix-mqs`, it instead uses `$fix-breakpoint`. I'm not completely familiar with the ins and outs of the Breakpoint library, but I have tried my best to incorporate here.
