### PR TITLE
Add (min|max) resolution to breakpoint-string-value()

### DIFF
--- a/stylesheets/breakpoint/_helpers.scss
+++ b/stylesheets/breakpoint/_helpers.scss
@@ -58,7 +58,7 @@
 // Returns whether the feature can have a string value
 //////////////////////////////
 @function breakpoint-string-value($feature) {
-  @if $feature == 'orientation' or $feature == 'scan' or $feature == 'color' {
+@if $feature == 'orientation' or $feature == 'scan' or $feature == 'color' or $feature == 'resolution' or $feature == 'min-resolution' or $feature == 'max-resolution' {
     @return true;
   }
   @else {


### PR DESCRIPTION
Right now when I use `@include breakpoint(resolution 1.3dppx) {}`, the feature and value are switched by lines 256+ in _breakpoint.scss:

```
      @if breakpoint-string-value(nth($breakpoint, 1)) == true {
        $feature: nth($breakpoint, 1);
        $value: nth($breakpoint, 2);
      }
      @else {
        $feature: nth($breakpoint, 2);
        $value: nth($breakpoint, 1);
      }
```

Adding resolution, min-resolution, and max-resolution to `breakpoint-string-value()` should fix it right up. If I'm missing some obvious way to use resolution media queries and causing my own problems, let me know.

**[Edit]** I see that in the hi-res example using `device-pixel-ratio` you reverse the feature and value (`2 device-pixel-ratio`). What's the reasoning behind having some expressions in normal code order and some reversed?
