### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "compass-breakpoint",
+  "version": "2.0.5",
+  "main": "stylesheets/_breakpoint.scss",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "components",
+    "test"
+  ]
+}


### PR DESCRIPTION
Adding a bower.json so people can install Team Sass components with [Bower](http://bower.io). For each project I  specified component dependencies, excluded tests, and kept examples.

I referenced other Team Sass pull requests here so we can use this as a meta issue.

These PRs are a first pass. A couple notes things to be decided before we commit and register the projects as Bower packages.
- Breakpoint is in the Bower registry already. Everything else needs to be checked for naming collisions, and we should probably choose a standard naming convention.
- The packages register their dependencies, but I'm not sure how this is going to work in practice. [This issue](https://github.com/bower/bower/issues/292) leads me to believe that all dependencies will be installed alongside each other like npm peerDependencies, which would be perfect. Haven't tested yet though.
- Any dependencies outside of Team Sass I set with a git endpoint instead of submitting bower.json PRs. Opinions welcome.
