### PR TITLE
Add stylesheets path to SASS_PATH when Compass is not loaded

### DIFF
--- a/lib/breakpoint.rb
+++ b/lib/breakpoint.rb
@@ -4,6 +4,13 @@ if (defined? Compass)
     "breakpoint",
     :path => "#{File.dirname(__FILE__)}/.."
   )
+else
+  # Compass not defined, register on the Sass path via the environment.
+  if ENV.has_key?("SASS_PATH")
+    ENV["SASS_PATH"] = ENV["SASS_PATH"] + File::PATH_SEPARATOR + "#{File.dirname(__FILE__)}/../stylesheets"
+  else
+    ENV["SASS_PATH"] = "#{File.dirname(__FILE__)}/../stylesheets"
+  end
 end
 
 module Breakpoint


### PR DESCRIPTION
Fix for #98.

When Compass is not used, Breakpoint `stylesheets` path is added to `SASS_PATH` so that Breakpoint can be used with Sass compiler only, without Compass.