### PR TITLE
Set `SASS_PATH` when not using Compass.

### DIFF
--- a/lib/breakpoint.rb
+++ b/lib/breakpoint.rb
@@ -6,7 +6,7 @@ if (defined? Compass)
     :path => breakpoint_path
   )
 else
-  bourbon_path = File.expand_path("../../stylesheets", __FILE__)
+  breakpoint_path = File.expand_path("../../stylesheets", __FILE__)
   ENV["SASS_PATH"] = [ENV["SASS_PATH"], breakpoint_path].compact.join(File::PATH_SEPARATOR)
 end
 

--- a/lib/breakpoint.rb
+++ b/lib/breakpoint.rb
@@ -1,9 +1,13 @@
 if (defined? Compass)
   require 'sassy-maps'
+  breakpoint_path = File.expand_path("../..", __FILE__)
   Compass::Frameworks.register(
     "breakpoint",
-    :path => "#{File.dirname(__FILE__)}/.."
+    :path => breakpoint_path
   )
+else
+  bourbon_path = File.expand_path("../../stylesheets", __FILE__)
+  ENV["SASS_PATH"] = [ENV["SASS_PATH"], breakpoint_path].compact.join(File::PATH_SEPARATOR)
 end
 
 module Breakpoint


### PR DESCRIPTION
From Sass's [changelog](https://github.com/nex3/sass/blob/stable/doc-src/SASS_CHANGELOG.md) for v3.3.0 release

> The automatic placement of the current working directory onto the Sass load path is now deprecated as this causes unpredictable build processes. If you need the current working directory to be available, set SASS_PATH=. in your shell's environment.

This change would bring breakpoint up to other libs like Susy, Bourbon, etc. I also took the opportunity to use a full path for the compass framework too. I also noticed recently that CodeKit is leveraging `SASS_PATH` too.
