### PR TITLE
Change bower name from compass-breakpoint. Fixes #143

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "compass-breakpoint",
+  "name": "breakpoint-sass",
   "version": "2.6.1",
   "main": "stylesheets/_breakpoint.scss",
   "ignore": [


### PR DESCRIPTION
Over in #143, people are reporting weird behavior when installing via bower.

This PR is the sanest approach, imo.

There is a side effect of this though. People installing using the command `bower install compass-breakpoint --save-dev` will report "weird" behavior that the folder is being renamed to "breakpoint-sass". But we should tell them not to do that.