### PR TITLE
Fix filenames for README & CHANGELOG in the gemspec.

### DIFF
--- a/breakpoint.gemspec
+++ b/breakpoint.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT", "GPL-2.0"]
 
   # Gem Files
-  s.files = ["README.markdown"]
-  s.files += ["CHANGELOG.markdown"]
+  s.files = ["README.md"]
+  s.files += ["CHANGELOG.md"]
   s.files += Dir.glob("lib/**/*.*")
   s.files += Dir.glob("stylesheets/**/*.*")
 


### PR DESCRIPTION
Was unable to run `gem build breakpoint.gemspec` due to missing files. After this change, the gem file builds successfully.

This is a likely explanation for why the current version has not been picked-up by ruby gem repos. (fixes #146, or at least gets close to resolving the issue.)