### PR TITLE
🐛 fixes #188

### DIFF
--- a/stylesheets/breakpoint/_helpers.scss
+++ b/stylesheets/breakpoint/_helpers.scss
@@ -25,16 +25,16 @@
   $unit: unit($value);
 
   @if $unit == 'px' {
-    @return $value / 16px * 1em;
+    @return calc($value / 16px) * 1em;
   }
   @else if $unit == '%' {
-    @return $value / 100% * 1em;
+    @return calc($value / 100%) * 1em;
   }
   @else if $unit == 'em' {
     @return $value;
   }
   @else if $unit == 'pt' {
-    @return $value / 12pt * 1em;
+    @return calc($value / 12pt) * 1em;
   }
   @else {
     @return $value;

--- a/stylesheets/breakpoint/_helpers.scss
+++ b/stylesheets/breakpoint/_helpers.scss
@@ -1,6 +1,9 @@
 //////////////////////////////
 // Converts the input value to Base EMs
 //////////////////////////////
+
+@use "sass:math";
+
 @function breakpoint-to-base-em($value) {
   $value-unit: unit($value);
 
@@ -25,16 +28,16 @@
   $unit: unit($value);
 
   @if $unit == 'px' {
-    @return calc($value / 16px) * 1em;
+    @return math.div($value / 16px) * 1em;
   }
   @else if $unit == '%' {
-    @return calc($value / 100%) * 1em;
+    @return math.div($value / 100%) * 1em;
   }
   @else if $unit == 'em' {
     @return $value;
   }
   @else if $unit == 'pt' {
-    @return calc($value / 12pt) * 1em;
+    @return math.div($value / 12pt) * 1em;
   }
   @else {
     @return $value;


### PR DESCRIPTION
This addresses the deprecation warning below.

```bash
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($value, 16px) or calc($value / 16px)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
28 │     @return $value / 16px * 1em;
   │             ^^^^^^^^^^^^^
   ╵
    node_modules/breakpoint-sass/stylesheets/breakpoint/_helpers.scss 28:13                 base-conversion()
    node_modules/breakpoint-sass/stylesheets/breakpoint/_helpers.scss 20:13                 breakpoint-to-base-em()
    node_modules/breakpoint-sass/stylesheets/breakpoint/parsers/double/_default.scss 18:13  breakpoint-parse-double-default()
    node_modules/breakpoint-sass/stylesheets/breakpoint/parsers/_double.scss 29:14          breakpoint-parse-double()
    node_modules/breakpoint-sass/stylesheets/breakpoint/_parsers.scss 178:20                breakpoint-parse()
    node_modules/breakpoint-sass/stylesheets/breakpoint/_parsers.scss 48:22                 breakpoint()
    node_modules/breakpoint-sass/stylesheets/_breakpoint.scss 46:16                         breakpoint()
```